### PR TITLE
Use webpack tilde syntax for loading CSS from node_modules folder

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,8 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
 
-@import "../node_modules/materialize-css/sass/components/color"; /* This must be included to use the included variables and the color function */
+@import "~materialize-css/sass/components/color"; /* This must be included to use the included variables and the color function */
 $primary-color: color("indigo", "base");
 $secondary-color: color("blue", "lighten-1");
 
-$roboto-font-path: "../node_modules/materialize-css/fonts/roboto/"; /* This is needed so the materialize.scss file can load the font */
-@import "../node_modules/materialize-css/sass/materialize";
+$roboto-font-path: "~materialize-css/fonts/roboto/"; /* This is needed so the materialize.scss file can load the font */
+@import "~materialize-css/sass/materialize";


### PR DESCRIPTION
This is a better but undocumented way of importing CSS "like a module". See https://github.com/webpack/css-loader/issues/12